### PR TITLE
Unification was abstracted from list-based substitution

### DIFF
--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -9,6 +9,8 @@ import           Stream
 import           Syntax
 import           Text.Printf
 
+import qualified Data.Map.Strict as Map
+
 class Substitution s where
   sEmpty  :: s
   sLookup :: S -> s -> Maybe Ts
@@ -18,6 +20,13 @@ instance Substitution Sigma where
   sEmpty = []
   sLookup a s = lookup a s
   sInsert a b s = (a, b) : s
+
+type MapSigma = Map.Map S Ts
+
+instance Substitution MapSigma where
+  sEmpty  = Map.empty
+  sLookup = Map.lookup
+  sInsert = Map.insert
 
 -- States
 type Iota  = ([X], X -> Ts)

--- a/src/Eval.hs
+++ b/src/Eval.hs
@@ -90,7 +90,7 @@ unifySubsts one two =
     manifactureTerm upper subst = C "ManifacturedTerm" $ map snd $ supplement upper subst
 
 unifyNoOccursCheck :: Substitution subst => Maybe subst -> Ts -> Ts -> Maybe subst
-unifyNoOccursCheck = unifyG (\_ _ -> const True)
+unifyNoOccursCheck = unifyG (\_ _ -> const False)
 
 ---- Interpreting syntactic variables
 infix 9 <@>


### PR DESCRIPTION
Also map-based substitution was added. And typo was fixed in 'unifyNoOccursCheck'.